### PR TITLE
Revert "Bump python-Levenshtein version to 0.25.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # pre-commit hooks for pylint & mypy
 beautifulsoup4~=4.11.0
 thefuzz~=0.19.0
-python-Levenshtein~=0.25.0
+python-Levenshtein~=0.12.0
 python-telegram-bot[job-queue]==20.2
 Sphinx~=5.0.2
 httpx~=0.23.0


### PR DESCRIPTION
Reverts bqback/rules-bot#1